### PR TITLE
output: propagate back-pressure when connection is blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
      - [RabbitMQ Output Plugin @5.1.1](https://github.com/logstash-plugins/logstash-output-rabbitmq/blob/v5.1.1/CHANGELOG.md)
   - Absorbed connection mixin dependency; independent changelog history for
     the mixin can be found here: [RabbitMQ Connection Mixin @5.1.0](https://github.com/logstash-plugins/logstash-mixin-rabbitmq_connection/blob/v5.1.0/CHANGELOG.md)
+  - In the Output plugin, when a connection is flagged as blocked, back-pressure is now propagated to the pipeline until the connection is either unblocked or recovered, preventing runaway writes to blocked connections ([#1](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/1))

--- a/logstash-integration-rabbitmq.gemspec
+++ b/logstash-integration-rabbitmq.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'march_hare', ['~> 4.0'] #(MIT license)
   s.add_runtime_dependency 'stud', '~> 0.0.22'
+  s.add_runtime_dependency 'back_pressure', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-input-generator'

--- a/spec/outputs/rabbitmq_spec.rb
+++ b/spec/outputs/rabbitmq_spec.rb
@@ -60,6 +60,8 @@ describe LogStash::Outputs::RabbitMQ do
       allow(connection).to receive(:on_blocked)
       allow(connection).to receive(:on_unblocked)
       allow(connection).to receive(:on_shutdown)
+      allow(connection).to receive(:on_recovery_started)
+      allow(connection).to receive(:on_recovery)
       allow(channel).to receive(:exchange).and_return(exchange)
 
       instance.register


### PR DESCRIPTION
When the other end of a RabbitMQ connection is either unwilling or unable to
continue reading bytes from its underlying TCP stream, the connection is
flagged as "blocked", but attempts to publish onto exchanges using the
connection will not block in the client.

Here we hook into notifications of connection-blocked state to set up a
`BackPressure::GatedExecutor`, which is used to prevent runaway writes when
publishing to an exchange on a blocked connection.
