### PR TITLE
fix failure to register connection recovery hooks in output plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.0.2
+  - Fixes issue in Output where failure to register connection reovery hooks prevented the output from starting
+
 ## 7.0.1
   - Improves Input Plugin documentation to better align with upstream guidance [#4](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/4)
 

--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -118,7 +118,7 @@ module LogStash
           march_hare_connection.on_unblocked do
             executor.remove_back_pressure('connection flagged as unblocked')
           end
-          march_hare_connection.on_recovery_started do
+          march_hare_connection.on_recovery_start do
             executor.engage_back_pressure("connection is being recovered")
           end
           march_hare_connection.on_recovery do

--- a/logstash-integration-rabbitmq.gemspec
+++ b/logstash-integration-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-rabbitmq'
-  s.version         = '7.0.1'
+  s.version         = '7.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Integration with RabbitMQ - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/spec/outputs/rabbitmq_spec.rb
+++ b/spec/outputs/rabbitmq_spec.rb
@@ -60,7 +60,7 @@ describe LogStash::Outputs::RabbitMQ do
       allow(connection).to receive(:on_blocked)
       allow(connection).to receive(:on_unblocked)
       allow(connection).to receive(:on_shutdown)
-      allow(connection).to receive(:on_recovery_started)
+      allow(connection).to receive(:on_recovery_start)
       allow(connection).to receive(:on_recovery)
       allow(channel).to receive(:exchange).and_return(exchange)
 


### PR DESCRIPTION
Connection recovery hooks, as released in March Hare 4.0.0, provide an
`Session#on_recovery_start`, not `Session#on_recovery_started`.
