### PR TITLE
Clarify rabbitMQ properties which are accepted.

### DIFF
--- a/docs/output-rabbitmq.asciidoc
+++ b/docs/output-rabbitmq.asciidoc
@@ -169,7 +169,7 @@ Key to route to by default. Defaults to 'logstash'
   * Value type is <<hash,hash>>
   * Default value is `{}`
 
-Add properties to be set per-message here, such as 'content_type', 'priority'.
+Add properties to be set per-message here which are https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_management/priv/www/js/global.js#L345[supported by the server], such as 'app_id', 'content_type', 'priority'. 
 Values can be {logstash-ref}/event-dependent-configuration.html#sprintf[`sprintf` templates], whose value for each message will be populated from the event.
 
 Example:


### PR DESCRIPTION
RabbitMQ when publishing has a set limit of accepted properties. Adding a link to available properties should be useful. 
There is a miss match between consuming and publishing properties. 
Eg. app_id when publishing becomes app-id when consuming. 

Adding links to server code which enumerates this can be helpful.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
