### PR TITLE
Fixed Queue documentation

### DIFF
--- a/docs/input-rabbitmq.asciidoc
+++ b/docs/input-rabbitmq.asciidoc
@@ -317,21 +317,6 @@ messages allowed.
   * Value type is <<string,string>>
   * Default value is `""`
 
-The properties to extract from each message and store in a
-@metadata field.
-
-Technically the exchange, redeliver, and routing-key
-properties belong to the envelope and not the message but we
-ignore that distinction here. However, we extract the
-headers separately via get_headers even though the header
-table technically is a message property.
-
-Freezing all strings so that code modifying the event's
-@metadata field can't touch them.
-
-If updating this list, remember to update the documentation
-above too.
-The default codec for this plugin is JSON. You can override this to suit your particular needs however.
 The name of the queue Logstash will consume events from. If
 left empty, a transient queue with an randomly chosen name
 will be created.


### PR DESCRIPTION
Fixed queue documentation issue that I found while reading the Elastic documetnation. 
Removed seemingly unrelated documentation from this section (since as far as I can tell, it is not related to queues).

I quickly checked, and did not find sections where this unrelated information might need to go, so I simply removed it altogether.

Fixes issue https://github.com/logstash-plugins/logstash-integration-rabbitmq/issues/49

I assume once the PR is merged, the changes will be reflected on the Elastic website. If this assumption is incorrect feel free to let me know.