### PR TITLE
docs: clarify availability/cost of metadata when a user opts in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.3.1
+  - DOCS: clarify the availability and cost of using the `metadata_enabled` option [#52](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/52)
+
 ## 7.3.0
   - Refactor: logging improvements [#47](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/47)
     * integrated MarchHare logging to be part of Logstash's log instead of using std-err

--- a/docs/input-rabbitmq.asciidoc
+++ b/docs/input-rabbitmq.asciidoc
@@ -271,7 +271,18 @@ This is only relevant for direct or topic exchanges.
     - `true`: deprecated alias for `basic`
   * Default value is `none`
 
-Enable the storage of message headers and properties in `@metadata`. This may impact performance
+Enable metadata about the RabbitMQ topic to be added to the event's `@metadata` field, for availablity during pipeline processing. In general, most output plugins and codecs do not include `@metadata` fields. This may impact memory usage and performance.
+
+[id="plugins-{type}s-{plugin}-metadata_locations"]
+====== Metadata mapping
+|=====
+| category | location | type
+
+| headers        |`[@metadata][rabbitmq_headers]` | key/value map
+| properties     |`[@metadata][rabbitmq_properties]` | key/value map
+| raw payload    |`[@metadata][rabbitmq_payload]` | byte sequence
+|=====
+
 
 [id="plugins-{type}s-{plugin}-passive"]
 ===== `passive`

--- a/logstash-integration-rabbitmq.gemspec
+++ b/logstash-integration-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-rabbitmq'
-  s.version         = '7.3.0'
+  s.version         = '7.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Integration with RabbitMQ - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
Docs change to add clarity to the availability and cost of using `metadata_enabled` option.