### PR TITLE
Change TLS certificate password type to  to protect leaking in logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.3.2
+  - Change `tls_certificate_password` type to `password` to protect from leaks in the logs [#54](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/54)
+
 ## 7.3.1
   - DOCS: clarify the availability and cost of using the `metadata_enabled` option [#52](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/52)
 

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -85,7 +85,7 @@ module LogStash
         config :tls_certificate_path, :validate => :path, :obsolete => "This setting is obsolete. Use ssl_certificate_path instead"
 
         # TLS certificate password
-        config :tls_certificate_password, :validate => :string, :obsolete => "This setting is obsolete. Use ssl_certificate_password instead"
+        config :tls_certificate_password, :validate => :password, :obsolete => "This setting is obsolete. Use ssl_certificate_password instead"
 
         # Extra queue arguments as an array.
         # To make a RabbitMQ queue mirrored, use: `{"x-ha-policy" => "all"}`

--- a/logstash-integration-rabbitmq.gemspec
+++ b/logstash-integration-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-rabbitmq'
-  s.version         = '7.3.1'
+  s.version         = '7.3.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Integration with RabbitMQ - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
When using config debug option, `tls_certificate_password` value can be seen in the logs.
This PR intends to change `tls_certificate_password` type to `password` to protect from leaks in the logs.