### PR TITLE
Fix the cancellation flow to avoid multiple invocations of basic.cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.3.3
+  - Fixed the cancellation flow to avoid multiple invocations of basic.cancel [#55](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/55)
+
 ## 7.3.2
   - Change `tls_certificate_password` type to `password` to protect from leaks in the logs [#54](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/54)
 

--- a/logstash-integration-rabbitmq.gemspec
+++ b/logstash-integration-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-rabbitmq'
-  s.version         = '7.3.2'
+  s.version         = '7.3.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Integration with RabbitMQ - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
There are two flows to shutdown the RabbitMQ consumers. When the plugin is the one shutting it down, it should send a channel cancellation message by invoking `@hare_info.channel.basic_cancel(@consumer.consumer_tag)` and waiting for the consumer to terminate (once the broker replies with a `basic.cancel-ok` message). This back-and-forth is handled by the MarchHare client. On the other hand, when the broker requests the client to shut down (eg. due to queue deletion). It sends the client a `basic.cancel` message, which is handled internally by the client (`handleCancel`), unregistering the consumer and then invoking the `:on_cancellation` callback. In that case, the plugin should not do anything as the consumer is already canceled/unregistered.

This PR adds an extra condition on the shutdown to check whether the client is already canceled/terminated (by the broker) or if it should execute the plugin cancellation flow.

---
Closes: https://github.com/logstash-plugins/logstash-integration-rabbitmq/issues/40