### PR TITLE
Removed obsolete `verify_ssl` and `debug` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.0.0
+## 7.4.0
   - Removed obsolete `verify_ssl` and `debug` options [#60](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/60)
 
 ## 7.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 8.0.0
-  - Removed obsolete `verify_ssl` and `debug` options
+  - Removed obsolete `verify_ssl` and `debug` options [#60](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/60)
 
 ## 7.3.3
   - Fixed the cancellation flow to avoid multiple invocations of basic.cancel [#55](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/55)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.0.0
+  - Removed obsolete `verify_ssl` and `debug` options
+
 ## 7.3.3
   - Fixed the cancellation flow to avoid multiple invocations of basic.cancel [#55](https://github.com/logstash-plugins/logstash-integration-rabbitmq/pull/55)
 

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -54,17 +54,11 @@ module LogStash
         # Version of the SSL protocol to use.
         config :ssl_version, :validate => :string, :default => "TLSv1.2"
 
-        config :verify_ssl, :validate => :boolean, :default => false,
-          :obsolete => "This function did not actually function correctly and was removed." +
-                       "If you wish to validate SSL certs use the ssl_certificate_path and ssl_certificate_password options."
-
         # Path to an SSL certificate in PKCS12 (.p12) format used for verifying the remote host
         config :ssl_certificate_path, :validate => :path
 
         # Password for the encrypted PKCS12 (.p12) certificate file specified in ssl_certificate_path
         config :ssl_certificate_password, :validate => :password
-
-        config :debug, :validate => :boolean, :obsolete => "Use the logstash --debug flag for this instead."
 
         # Set this to automatically recover from a broken connection. You almost certainly don't want to override this!!!
         config :automatic_recovery, :validate => :boolean, :default => true

--- a/logstash-integration-rabbitmq.gemspec
+++ b/logstash-integration-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-rabbitmq'
-  s.version         = '7.3.3'
+  s.version         = '8.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Integration with RabbitMQ - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+

--- a/logstash-integration-rabbitmq.gemspec
+++ b/logstash-integration-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-integration-rabbitmq'
-  s.version         = '8.0.0'
+  s.version         = '7.4.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Integration with RabbitMQ - input and output plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline "+


### PR DESCRIPTION
remove verify_ssl and debug
CI red is unrelated to this change