### PR TITLE
Add support for max_inbound_message_body_size parameter. Fixes #59

### DIFF
--- a/docs/input-rabbitmq.asciidoc
+++ b/docs/input-rabbitmq.asciidoc
@@ -96,6 +96,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-key>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-metadata_enabled>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-max_inbound_message_body_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-passive>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
@@ -258,6 +259,13 @@ This is only relevant for direct or topic exchanges.
 
 * Routing keys are ignored on fanout exchanges.
 * Wildcards are not valid on direct exchanges.
+
+[id="plugins-{type}s-{plugin}-max_inbound_message_body_size"]
+===== `max_inbound_message_body_size`
+
+  * Value type is <<number,number>>
+
+If unspecified then max_inbound_message_body_size of 67108864 bytes will be used.
 
 [id="plugins-{type}s-{plugin}-metadata_enabled"]
 ===== `metadata_enabled`

--- a/lib/logstash/plugin_mixins/rabbitmq_connection.rb
+++ b/lib/logstash/plugin_mixins/rabbitmq_connection.rb
@@ -72,6 +72,9 @@ module LogStash
         # Heartbeat delay in seconds. If unspecified no heartbeats will be sent
         config :heartbeat, :validate => :number
 
+        # Max inbound message size in bytes. If not specified default value of 67108864 bytes will be used
+        config :max_inbound_message_body_size, :validate => :number
+
         # Passive queue creation? Useful for checking queue existance without modifying server state
         config :passive, :validate => :boolean, :default => false
 
@@ -104,6 +107,7 @@ module LogStash
 
         s[:connection_timeout] = @connection_timeout || 0
         s[:requested_heartbeat] = @heartbeat || 0
+        s[:max_inbound_message_body_size] = @max_inbound_message_body_size || 67108864
 
         if @ssl
           s[:tls] = @ssl_version

--- a/spec/plugin_mixins/rabbitmq_connection_spec.rb
+++ b/spec/plugin_mixins/rabbitmq_connection_spec.rb
@@ -50,6 +50,7 @@ describe LogStash::PluginMixins::RabbitMQConnection do
 
     let(:rabbitmq_settings) { super().merge({"connection_timeout" => 123,
                                            "heartbeat" => 456,
+                                           "max_inbound_message_body_size" => 789,
                                            "ssl" => true,
                                            "ssl_version" => "TLSv1.1",
                                            "ssl_certificate_path" => path,
@@ -61,6 +62,10 @@ describe LogStash::PluginMixins::RabbitMQConnection do
 
     it "should set heartbeat to the expected value" do
       expect(instance.rabbitmq_settings[:requested_heartbeat]).to eql(rabbitmq_settings["heartbeat"])
+    end
+
+    it "should set max_inbound_message_body_size to the expected value" do
+      expect(instance.rabbitmq_settings[:max_inbound_message_body_size]).to eql(rabbitmq_settings["max_inbound_message_body_size"])
     end
 
     it "should set tls to the expected value" do


### PR DESCRIPTION
Hi,
This pull request adds a possibility for a logstash user to configure maximum inbound message body size for messages fetched from a RabbitMQ queue by logstash above (or below) the default limit of the RabbitMQ connector - 67108864 bytes - currently set as a not configurable default by logstash.
Therefore it fixes issue #59.

Best regards
mp107