### PR TITLE
Remove 8.previous test definitions from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ before_script:
 
 jobs:
   include:
-    - env: INTEGRATION=true ELASTIC_STACK_VERSION=8.previous
     - env: INTEGRATION=true ELASTIC_STACK_VERSION=8.current
     - env: INTEGRATION=true ELASTIC_STACK_VERSION=9.current
     - env: INTEGRATION=true ELASTIC_STACK_VERSION=9.previous
-    - env: INTEGRATION=true SNAPSHOT=true ELASTIC_STACK_VERSION=8.previous
     - env: INTEGRATION=true SNAPSHOT=true ELASTIC_STACK_VERSION=8.current
     - env: INTEGRATION=true SNAPSHOT=true ELASTIC_STACK_VERSION=9.previous
     - env: INTEGRATION=true SNAPSHOT=true ELASTIC_STACK_VERSION=9.current


### PR DESCRIPTION
The 8.previous stack version alias is being retired. Remove the corresponding integration test entries.
