### PR TITLE
Pin the integration test container

### DIFF
--- a/.ci/integration/docker-compose.override.yml
+++ b/.ci/integration/docker-compose.override.yml
@@ -15,7 +15,7 @@ services:
     environment:
       RABBITMQ_HOST: "rabbitmq"
   rabbitmq:
-    image: rabbitmq:latest
+    image: rabbitmq:3.13.7
     hostname: rabbit
     ports:
       - "15672:5672"


### PR DESCRIPTION
Pin to the last known good 3.x series of the rabbitmq container. The 4.x series has deprecated transient_nonexcl_queues which is breaking the plugin config.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
